### PR TITLE
Add Rubocop check to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,33 +1,25 @@
-version: 2.1 # Use 2.1 to enable using orbs and other features.
+version: 2.1
 
-# Declare the orbs that we'll use in our config.
-# read more about orbs: https://circleci.com/docs/2.0/using-orbs/
 orbs:
   ruby: circleci/ruby@1.1.4
 
 jobs:
   rspec:
-    # we run "parallel job containers" to enable speeding up our tests;
-    # this splits our tests across multiple containers.
-    parallelism: 1
-    # here we set TWO docker images.
     docker:
-      - image: cimg/ruby:3.0 # this is our primary docker image, where step commands run.
+      - image: cimg/ruby:3.0
         auth:
           username: mydockerhub-user
-          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
+          password: $DOCKERHUB_PASSWORD
       - image: timescale/timescaledb-postgis:latest-pg13
         auth:
           username: mydockerhub-user
-          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
-        environment: # add POSTGRES environment variables.
+          password: $DOCKERHUB_PASSWORD
+        environment:
           POSTGRES_USER: circleci-demo-ruby
           POSTGRES_DB: albuvideo_api_test
           POSTGRES_HOST_AUTH_METHOD: trust
           POSTGRES_PASSWORD: ""
       - image: circleci/redis:alpine
-
-    # environment variables specific to Ruby/Rails, applied to the primary container.
     environment:
       BUNDLE_JOBS: "3"
       BUNDLE_RETRY: "3"
@@ -35,12 +27,9 @@ jobs:
       PGUSER: circleci-demo-ruby
       PGPASSWORD: ""
       RAILS_ENV: test
-    # A series of steps to run, some are similar to those in "build".
     steps:
       - checkout
       - ruby/install-deps
-      # Here we make sure that the secondary container boots
-      # up before we run operations on the database.
       - run:
           name: Install FFmpeg
           command: sudo apt update && sudo apt install -y ffmpeg
@@ -50,25 +39,26 @@ jobs:
       - run:
           name: Database setup
           command: bundle exec rails db:schema:load --trace
-      # Run rspec in parallel
       - ruby/rspec-test
 
-  build:
+  rubocop:
     docker:
-      - image: cimg/ruby:3.0 # use a tailored CircleCI docker image.
+      - image: cimg/ruby:3.0
         auth:
           username: mydockerhub-user
-          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
+          password: $DOCKERHUB_PASSWORD
     steps:
-      - checkout # pull down our git code.
-      - ruby/install-deps # use the ruby orb to install dependencies
+      - checkout
+      - ruby/install-deps
+      - run:
+          name: Run rubocop
+          command: bundle exec rubocop
 
-# We use workflows to orchestrate the jobs that we declared above.
 workflows:
   version: 2
-  build_and_test:
+  Rubocop:
     jobs:
-      - build
-      - rspec:
-          requires:
-            - build
+      - rubocop
+  RSpec:
+    jobs:
+      - rspec

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,7 @@ AllCops:
   Exclude:
     - bin/*
     - db/schema.rb
+    -  vendor/**/*
 
 Style/Documentation:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,5 +24,8 @@ Metrics/BlockLength:
   Exclude:
     - spec/*/**
 
+Metrics/MethodLength:
+  CountAsOne: ['array', 'heredoc', 'hash']
+
 RSpec/MultipleMemoizedHelpers:
   Enabled: false

--- a/app/services/split_variant_into_segments.rb
+++ b/app/services/split_variant_into_segments.rb
@@ -31,12 +31,11 @@ class SplitVariantIntoSegments
       variant.transcoded_file.open do |file|
         input_path = file.path
         system(
-          "ffmpeg -i #{input_path} -y -loglevel error -c:v copy -c:a copy -vbsf h264_mp4toannexb -hls_time 6 -hls_list_size 0"\
-          "-hls_segment_filename '#{segment_path}' #{playlist_path}",
+          "ffmpeg -i #{input_path} -y -loglevel error -c:v copy -c:a copy -vbsf h264_mp4toannexb -hls_time 6"\
+          " -hls_list_size 0 -hls_segment_filename '#{segment_path}' #{playlist_path}",
           exception: true
         )
       end
-      File.delete(segment_path)
     end
 
     def create_segments(playlist, variant)


### PR DESCRIPTION
- Add Rubocop check to CircleCI configuration
- Remove comments from CircleCI configuration
- Configure Rubocop to consider arrays, hashes, and heredocs a single line when calculating method length
- Fixed `system` line length
- Fixed a bug caused by missing whitespace in the `system` command causing an additional file being created