### PR TITLE
Remove citext extension from schema.rb

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,7 +13,6 @@
 ActiveRecord::Schema.define(version: 2021_08_30_220629) do
 
   # These are extensions that must be enabled in order to support this database
-  enable_extension "citext"
   enable_extension "plpgsql"
   enable_extension "timescaledb"
 


### PR DESCRIPTION
The migration containing `citext` was not merged, but it is still present in `schema.rb`.

This PR removes it from `schema.rb`, avoiding this file to be updated when running migrations locally.